### PR TITLE
Add Live Tennis API to API & Data (live tennis match-state feed for Polymarket/Kalshi tennis markets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ A curated list of awesome Polymarket trading tools, bots, and analytics platform
 
 ---
 
+### [Live Tennis API Real-Time Match-State Feed for Polymarket and Kalshi Tennis Markets](https://livetennisapi.com/)
+
+> Live Tennis API is a real-time tennis data feed delivering live match state — score, current server, a three-valued break-point flag, and retirement, walkover, and completion status across ATP, WTA, Challenger, and ITF — so traders can enrich Polymarket and Kalshi tennis event markets with in-match signals, with a free no-card tier for live scores, players, and fixtures.
+
+---
+
 ## Alerts & Notifications
 <a name="alerts-notifications"></a>
 


### PR DESCRIPTION
Adds one entry to the **API & Data** section — a live tennis match-state data feed for traders working Polymarket/Kalshi tennis event markets.

Why this section: the API & Data intro invites "APIs, data feeds, and developer tools... real-time odds, historical data, and market analytics to build your own trading edge or application." This is a data feed of that kind (like the unrated entries PMXT, Predexon, Dome) — it's not a Polymarket odds source; it's a complementary live tennis signal (score, server, break-point flag, retirement/walkover/completion) you fold into a tennis event-market strategy. Data feed only, not a venue or execution adapter.

Format: I matched the section's unrated keyword-descriptive title style. I left off the trailing `[ℹ️](...)` link because those point to your own directory (polyzone.app / polymart.app) — happy for you to add the matching directory link, or I can adjust the entry however you prefer.

Entry:

### [Live Tennis API Real-Time Match-State Feed for Polymarket and Kalshi Tennis Markets](https://livetennisapi.com/)

> Live Tennis API is a real-time tennis data feed delivering live match state — score, current server, a three-valued break-point flag, and retirement, walkover, and completion status across ATP, WTA, Challenger, and ITF — so traders can enrich Polymarket and Kalshi tennis event markets with in-match signals, with a free no-card tier for live scores, players, and fixtures.

Free tier (no card, 30/min, 100/day): https://livetennisapi.com/subscribe/free
Open-source observe-only reference toolkit (MIT): https://github.com/livetennisapi/polymarket-tennis

Disclosure: I run the Live Tennis API — judge on the merits.