### PR TITLE
Add OpenThomas to AI Trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ A curated list of awesome Polymarket trading tools, bots, and analytics platform
 
 ---
 
+### [OpenThomas](https://github.com/PredictionMarketTrader/openthomas)
+
+> OpenThomas is an autonomous AI agent that trades weather markets on Kalshi and Polymarket. It maps every market to its exact NWS station, builds a per-strike probability from a 7-model forecast consensus, learns each station's systematic bias from months of leak-free hindcasts, lets an LLM adjust within hard bounds, and sizes every position with Brier-skill-gated Kelly.
+
+---
+
 ## API & Data
 <a name="api-data"></a>
 


### PR DESCRIPTION
Adding **OpenThomas** to the AI Trading section.

OpenThomas is an autonomous AI agent that trades weather markets on **Kalshi** and **Polymarket**. It maps every market to its exact NWS station, builds a per-strike probability from a 7-model forecast consensus, learns each station's systematic bias from months of leak-free hindcasts, lets an LLM adjust within hard bounds, and sizes every position with Brier-skill-gated Kelly.

- MIT-licensed Python CLI on PyPI (`openthomas`)
- Exposes an MCP server
- Built for transparent "trade in public" reporting

Repo: https://github.com/PredictionMarketTrader/openthomas

Note: this tool is not yet listed on polyzone.app, so I omitted the rating line. Happy to add it once it's indexed there, or to add a placeholder if you prefer consistent formatting across the list.