### PR TITLE
Add Dimes Multiply to DeFi & On-Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,12 @@ A curated list of awesome Polymarket trading tools, bots, and analytics platform
 
 ---
 
+### [Dimes Multiply](https://dimes.fi/multiply)
+
+> Dimes Multiply is an embedded leverage layer that apps, wallets, and terminals integrate through a REST API to offer their own users 2x to 10x on Polymarket positions, with the credit provisioning, hedging, and settlement handled by Dimes instead of the integrator.
+
+---
+
 ## News & Media
 <a name="news-media"></a>
 


### PR DESCRIPTION
Adds Dimes Multiply to `DeFi & On-Chain`.

Disclosure: I work on Dimes, so please weigh this accordingly — I've tried to write it to your house format rather than as a pitch.

The section already lists Gondor, Amplifi, Robin and HyperOdd, and the list elsewhere has Ultramarkets, Positions Finance and Perp.com, so the leverage/credit category is clearly in scope. Dimes sits at a different layer from most of those: it is B2B middleware rather than a venue — an app, wallet or terminal calls a REST API and Dimes provisions the credit, hedges it and settles it, so the integrating product never runs a margin book in-house. There is no Dimes front-end to trade on, which is why I've described it as a layer integrators use rather than a place traders go.

I left off the `[ℹ️]` polyzone.app link and the star rating since there's no Dimes page on your directory yet — happy for you to add both, or I can hold the PR until there is one.

Verified live today: dimes.fi/multiply (200), source at github.com/dimes-fi/dimes-sdk (MIT, TypeScript SDK published as `@dimes-dot-fi/sdk`).
